### PR TITLE
fix(WI-#52): 요약 편집 실제 저장 + Admin 중복 제거

### DIFF
--- a/src/app/(dashboard)/workspaces/[workspaceId]/meetings/[meetingId]/summary-review.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/meetings/[meetingId]/summary-review.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { updateSummaryText } from "@/modules/meeting";
 
 interface KeyDecision {
   decision: string;
@@ -44,12 +45,15 @@ export function SummaryReview({
 
   async function handleSave() {
     setSaving(true);
-    // 요약 텍스트 수정은 직접 DB 업데이트 (server action)
-    // 간단한 구현: PATCH API는 Phase 후반에 추가 가능
-    // 현재는 UI만 준비
-    setSaving(false);
-    setEditing(false);
-    router.refresh();
+    try {
+      await updateSummaryText(summary.id, text);
+      setEditing(false);
+      router.refresh();
+    } catch {
+      alert("요약 저장에 실패했습니다");
+    } finally {
+      setSaving(false);
+    }
   }
 
   return (

--- a/src/app/(dashboard)/workspaces/[workspaceId]/settings/member-list.tsx
+++ b/src/app/(dashboard)/workspaces/[workspaceId]/settings/member-list.tsx
@@ -156,9 +156,6 @@ function MemberRow({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              {currentUserRole === MembershipRole.OWNER && (
-                <SelectItem value="ADMIN">Admin</SelectItem>
-              )}
               <SelectItem value="ADMIN">Admin</SelectItem>
               <SelectItem value="MEMBER">Member</SelectItem>
             </SelectContent>

--- a/src/modules/meeting/index.ts
+++ b/src/modules/meeting/index.ts
@@ -2,6 +2,7 @@ export {
   createMeeting,
   createTextMeeting,
   getUploadUrl,
+  updateSummaryText,
 } from "./internal/actions";
 export {
   getMeetingsByWorkspace,

--- a/src/modules/meeting/internal/actions.ts
+++ b/src/modules/meeting/internal/actions.ts
@@ -155,3 +155,26 @@ export async function createTextMeeting(formData: FormData) {
   revalidatePath(`/workspaces/${workspaceId}/meetings`);
   redirect(`/workspaces/${workspaceId}/meetings/${meeting.id}`);
 }
+
+export async function updateSummaryText(
+  summaryId: string,
+  summaryText: string
+) {
+  const user = await requireUser();
+
+  const summary = await prisma.meetingSummary.findUniqueOrThrow({
+    where: { id: summaryId },
+    select: { meeting: { select: { workspaceId: true, id: true } } },
+  });
+
+  await requireWorkspaceMembership(user.id, summary.meeting.workspaceId);
+
+  await prisma.meetingSummary.update({
+    where: { id: summaryId },
+    data: { summary: summaryText },
+  });
+
+  revalidatePath(
+    `/workspaces/${summary.meeting.workspaceId}/meetings/${summary.meeting.id}`
+  );
+}


### PR DESCRIPTION
## Summary
- `updateSummaryText` server action 추가하여 요약 편집이 실제 DB에 저장되도록 수정
- 설정 페이지 멤버 역할 셀렉트에서 Admin 옵션 중복 표시 제거

## Test plan
- [ ] 회의 상세 → 검수 모드에서 요약 편집 → 저장 → 새로고침 후에도 반영 확인
- [ ] 설정 → 멤버 역할 변경 시 Admin이 1번만 표시되는지 확인
- [ ] `npm run build` + `npm test` 통과

closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)