### PR TITLE
fix(WI-#55): 업로드 RLS 우회 + 에러 페이지 추가

### DIFF
--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+export default function DashboardError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex flex-1 items-center justify-center">
+      <div className="text-center space-y-4">
+        <h2 className="text-xl font-semibold">문제가 발생했습니다</h2>
+        <p className="text-sm text-muted-foreground">{error.message}</p>
+        <button
+          onClick={reset}
+          className="rounded-md bg-primary px-4 py-2 text-sm text-primary-foreground"
+        >
+          다시 시도
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/supabase/admin.ts
+++ b/src/lib/supabase/admin.ts
@@ -1,0 +1,8 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  );
+}

--- a/src/modules/meeting/internal/actions.ts
+++ b/src/modules/meeting/internal/actions.ts
@@ -7,7 +7,7 @@ import { requireUser } from "@/modules/auth";
 import { requireWorkspaceMembership } from "@/modules/workspace";
 import { MeetingStatus } from "@prisma/client";
 import { isAllowedFile, isWithinSizeLimit } from "./constants";
-import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 export async function getUploadUrl(
   workspaceId: string,
@@ -26,7 +26,7 @@ export async function getUploadUrl(
     throw new Error("파일 크기가 500MB를 초과합니다");
   }
 
-  const supabase = await createClient();
+  const supabase = createAdminClient();
   const storagePath = `${workspaceId}/${Date.now()}-${fileName}`;
 
   const { data, error } = await supabase.storage


### PR DESCRIPTION
## Summary
- `getUploadUrl`에서 anon 클라이언트 → service_role admin 클라이언트로 변경하여 RLS 차단 해결
- `error.tsx` 추가로 서버 에러 시 백지 대신 에러 메시지 표시

## Test plan
- [ ] 파일 업로드 → 400 에러 없이 사전 서명 URL 정상 반환
- [ ] 서버 에러 발생 시 에러 메시지 + 다시 시도 버튼 표시
- [ ] `npm run build` + `npm test` 통과

closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)