### PR TITLE
fix: 업로드 후 자동 전사 트리거 추가 + fileUrl 수정

### DIFF
--- a/src/app/api/v1/meetings/[meetingId]/retry/route.ts
+++ b/src/app/api/v1/meetings/[meetingId]/retry/route.ts
@@ -54,7 +54,6 @@ export async function POST(
     if (!meeting.isTextPaste && meeting.assets[0]) {
       await tasks.trigger<typeof transcribeMeeting>("transcribe-meeting", {
         meetingId,
-        fileUrl: meeting.assets[0].storagePath,
       });
     }
 

--- a/src/modules/meeting/internal/actions.ts
+++ b/src/modules/meeting/internal/actions.ts
@@ -8,6 +8,8 @@ import { requireWorkspaceMembership } from "@/modules/workspace";
 import { MeetingStatus } from "@prisma/client";
 import { isAllowedFile, isWithinSizeLimit } from "./constants";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { tasks } from "@trigger.dev/sdk/v3";
+import type { transcribeMeeting } from "@/trigger/transcribe";
 
 export async function getUploadUrl(
   workspaceId: string,
@@ -108,6 +110,13 @@ export async function createMeeting(formData: FormData) {
         : undefined,
     },
   });
+
+  // 파일 업로드된 회의 → 자동 전사 트리거
+  if (storagePath) {
+    await tasks.trigger<typeof transcribeMeeting>("transcribe-meeting", {
+      meetingId: meeting.id,
+    });
+  }
 
   revalidatePath(`/workspaces/${workspaceId}/meetings`);
   redirect(`/workspaces/${workspaceId}/meetings/${meeting.id}`);

--- a/src/trigger/transcribe.ts
+++ b/src/trigger/transcribe.ts
@@ -5,6 +5,7 @@ import {
   isValidTransition,
   transitionMeetingStatus,
 } from "@/modules/meeting";
+import { createAdminClient } from "@/lib/supabase/admin";
 
 const VITO_API_BASE = "https://openapi.vito.ai";
 
@@ -105,15 +106,30 @@ async function pollTranscription(
 export const transcribeMeeting = task({
   id: "transcribe-meeting",
   maxDuration: 1800,
-  run: async (payload: { meetingId: string; fileUrl: string }) => {
-    const { meetingId, fileUrl } = payload;
+  run: async (payload: { meetingId: string }) => {
+    const { meetingId } = payload;
 
-    // 1. Meeting 상태 → PROCESSING
+    // 1. Meeting + Asset 조회
     const meeting = await prisma.meeting.findUnique({
       where: { id: meetingId },
+      include: { assets: { take: 1 } },
     });
 
     if (!meeting) throw new Error(`Meeting not found: ${meetingId}`);
+
+    const asset = meeting.assets[0];
+    if (!asset) throw new Error(`No asset found for meeting: ${meetingId}`);
+
+    // 2. Supabase Storage signed download URL 생성 (1시간 유효)
+    const supabase = createAdminClient();
+    const { data: urlData, error: urlError } = await supabase.storage
+      .from("meeting-assets")
+      .createSignedUrl(asset.storagePath, 3600);
+
+    if (urlError || !urlData?.signedUrl) {
+      throw new Error(`파일 다운로드 URL 생성 실패: ${urlError?.message}`);
+    }
+    const fileUrl = urlData.signedUrl;
 
     if (isValidTransition(meeting.status, MeetingStatus.PROCESSING)) {
       await transitionMeetingStatus(


### PR DESCRIPTION
## Summary
- `createMeeting()` 후 `transcribe-meeting` Trigger.dev 작업 자동 시작
- `transcribe` task가 직접 Supabase signed download URL을 생성하도록 변경 (기존: 상대 경로 전달 → fetch 실패)
- `retry` route도 동일하게 meetingId만 전달하도록 단순화

## Root Cause
업로드 후 Trigger.dev 전사 작업을 시작하는 코드가 없어서 모든 회의가 UPLOADED 상태에서 멈추고, 회의 상세 페이지에 아무 콘텐츠도 표시되지 않았음.

## Test plan
- [ ] tsc --noEmit 통과
- [ ] npm test 130개 통과
- [ ] npm run build 통과
- [ ] 프로덕션 배포 후 파일 업로드 → 자동 전사 시작 확인

closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)